### PR TITLE
Use a modified version of gloss (CAUTION: Probably not for merging.)

### DIFF
--- a/makefile
+++ b/makefile
@@ -18,15 +18,24 @@ Perspec.app: ~/.local/bin/perspec imagemagick
 
 
 imagemagick:
-	rm -f imagemagick.tar.gz
 	curl \
-		https://imagemagick.org/download/binaries/ImageMagick-x86_64-apple-darwin19.2.0.tar.gz \
+		https://imagemagick.org/download/binaries/ImageMagick-x86_64-apple-darwin19.6.0.tar.gz \
 		-o imagemagick.tar.gz
 	tar -xf imagemagick.tar.gz
 
 	rm -rf imagemagick
-	mv ImageMagick-7.0.9 imagemagick
+	mv ImageMagick-7.* imagemagick
 
 
 ~/.local/bin/perspec: app source
 	stack install
+
+
+.PHONY: clean
+clean:
+	-rm -rf \
+		~/.local/bin/perspec \
+		.stack-work \
+		imagemagick \
+		imagemagick.tar.gz \
+		Perspec.app \

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,3 +5,13 @@ packages:
 
 extra-deps:
   - gloss-juicy-0.2.3
+  - git: https://github.com/lancelet/gloss.git
+    commit: 4df890e4b764a53f2cb32e38e95aa4d515f80651
+    subdirs:
+      - gloss
+  - GLFW-b-1.4.8.4@sha256:b35242b401ac3235753f2bdfdfd07981f531e1d0457928caafb1db3801df40bc,2284
+
+flags:
+  gloss:
+    GLFW: true
+    GLUT: false

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -11,6 +11,26 @@ packages:
       sha256: 914c08509bc3da4707d90e542b44833ca1a62abc83c2848f87df3d7a7a1d7e03
   original:
     hackage: gloss-juicy-0.2.3
+- completed:
+    subdir: gloss
+    name: gloss
+    version: 1.13.1.2
+    git: https://github.com/lancelet/gloss.git
+    pantry-tree:
+      size: 3919
+      sha256: fa38fa0a665ddc4b546b22c48e5e9515feb0f57fffad2494f72a4341951a6ef7
+    commit: 4df890e4b764a53f2cb32e38e95aa4d515f80651
+  original:
+    subdir: gloss
+    git: https://github.com/lancelet/gloss.git
+    commit: 4df890e4b764a53f2cb32e38e95aa4d515f80651
+- completed:
+    hackage: GLFW-b-1.4.8.4@sha256:b35242b401ac3235753f2bdfdfd07981f531e1d0457928caafb1db3801df40bc,2284
+    pantry-tree:
+      size: 482
+      sha256: 8100262bac57570cc0d33cee874a6a1bcfcffdad224bbf6eea33c0032fd9fa52
+  original:
+    hackage: GLFW-b-1.4.8.4@sha256:b35242b401ac3235753f2bdfdfd07981f531e1d0457928caafb1db3801df40bc,2284
 snapshots:
 - completed:
     size: 524996


### PR DESCRIPTION
## CAUTION: Probably not for merging; best to wait for benl23x5 to decide what do to with the gloss PR

This PR and its branch is here to allow testing a [PR for gloss](https://github.com/benl23x5/gloss/pull/46) against Perspec `master`.

## Changes:

- Change `stack.yaml` to point to a specific commit in a fork of gloss that contains a potential fix for the HiDPI issue, in the GLFW backend.

- Use the GLFW backend.

- Specify a Hackage version of `GLFW-b` (since it's not included in this version of Stackage).