### PR TITLE
Update brew install command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ Step | Description                          | Result
 Install it via my [Homebrew](https://brew.sh) tap:
 
 ```sh
-brew cask install ad-si/tap/perspec
+brew install --cask ad-si/tap/perspec
 ```
 
 You can also get this (and previous) versions from


### PR DESCRIPTION
The command to install a cask recently changed from `brew cask install` to `brew install --cask`.

Others updating for the issue: https://github.com/ansible-collections/community.general/issues/1524
