### PR TITLE
Update ImageMagick url

### DIFF
--- a/makefile
+++ b/makefile
@@ -19,7 +19,7 @@ Perspec.app: ~/.local/bin/perspec imagemagick
 
 imagemagick:
 	curl \
-		https://imagemagick.org/download/binaries/ImageMagick-x86_64-apple-darwin20.1.0.tar.gz \
+		https://download.imagemagick.org/ImageMagick/download/binaries/ImageMagick-x86_64-apple-darwin20.1.0.tar.gz \
 		-o imagemagick.tar.gz
 	tar -xf imagemagick.tar.gz
 


### PR DESCRIPTION
The build command was failing because the ImageMagick url that was in the build file redirects and curl doesn't follow redirects by default.

This fixes that issue.

@ad-si 