### PR TITLE
Add Platypus requirement to build instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,10 @@ chmod +x \
 Build it from source with Haskell's
 [stack](https://docs.haskellstack.org/en/stable/install_and_upgrade/).
 
+Platypus, with 
+[command line tools enabled](https://github.com/sveinbjornt/Platypus/blob/master/Documentation/Documentation.md#show-shell-command)
+, is required to build from source.
+
 ```sh
 git clone https://github.com/ad-si/Perspec
 cd Perspec


### PR DESCRIPTION
When following the instructions to build from source (hoping to work around #9), there was an error since platypus wasn't installed. Even after installing Platypus there was an additional step of figuring out that CLI tools weren't enabled by default and enabling them.

PS: Please do edit the pr as you see fit and merge away!

Cheers