### PR TITLE
Fix GHC stack overflow during -O2 compilation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,7 @@ jobs:
       - name: Build Perspec App
         run: make Perspec.app
         env:
+          GHCRTS: -K64M
           STACK_OPTS: --ghc-options=-O2
 
       - name: Move App to Artifact Directory
@@ -131,6 +132,7 @@ jobs:
       - name: Build Perspec CLI tool
         run: make perspec
         env:
+          GHCRTS: -K64M
           STACK_OPTS: --ghc-options=-O2
 
       - name: Install AppImage


### PR DESCRIPTION
Add GHCRTS=-K64M environment variable to increase the stack size
available to GHC during compilation. The -O2 optimization flag
triggers aggressive optimization passes that require more stack
space than the default 33KB limit.